### PR TITLE
Fix generated YAML for git status record

### DIFF
--- a/record_metadata.sh
+++ b/record_metadata.sh
@@ -39,7 +39,8 @@ branch: $BRANCH
 commit: $COMMIT
 EOF
 
-LOCAL_CHANGES=$(git status --porcelain | sed 's/^/  /')
+# Get list of local changes and add a space to get two-space indent.
+LOCAL_CHANGES=$(git status --porcelain | sed 's/^/ /')
 
 if [[ "$LOCAL_CHANGES" ]]; then
     cat >>"$METADATA_FILE" <<EOF


### PR DESCRIPTION
First character of the git status --porcelain output is a space, so add only one
to get a well-formatted YAML accepted by linters. The space does not have any significance
(no mention of it in git status --help).
