### PR TITLE
Record metadata automatically, fix script name

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -5,17 +5,17 @@
 
 set -o errexit
 
-if [[ $# -ne 3 ]]; then
-    echo >&2 "Usage: $0 GRASS_VERSION LIB_PREFIX INSTALL_PREFIX"
+if [[ $# -ne 4 ]]; then
+    echo >&2 "Usage: $0 CODE_DIR GRASS_VERSION LIB_PREFIX INSTALL_PREFIX"
     exit 1
 fi
 
-GRASS_VERSION="$1"
-LIBS="$2"
-INSTALL_PREFIX="$3"
+CODE_DIR="$1"
+GRASS_VERSION="$2"
+LIBS="$3"
+INSTALL_PREFIX="$4"
 
 # Get the code
-CODE_DIR="grass-code-$GRASS_VERSION"
 git clone --depth=1 --branch "$GRASS_VERSION" https://github.com/OSGeo/grass.git "$CODE_DIR"
 cd "$CODE_DIR"
 

--- a/install_grass.sh
+++ b/install_grass.sh
@@ -50,11 +50,18 @@ install_version() {
         echo >&2 "Plain grass command is in bin, assuming symlink is not needed"
     fi
 
-    "$GRASS_INSTALL_REPO/create_modulefile.sh" \
+    "$GRASS_INSTALL_REPO/create_module_file.sh" \
         "$SYSTEM_CONDA_BIN" \
         "$CONDA_PREFIX" \
         "$INSTALL_PREFIX" \
         >"$MODULE_FILES_DIR/$GRASS_DOT_VERSION"
+
+    "$GRASS_INSTALL_REPO/record_metadata.sh" \
+        "$CONDA_PREFIX" \
+        "$GRASS_INSTALL_REPO/grass-code-$GRASS_DOT_VERSION" \
+        "$MODULE_FILES_DIR" \
+        "$GRASS_DOT_VERSION" \
+        "$GRASS_GIT_VERSION"
 }
 
 module load gcc

--- a/install_grass.sh
+++ b/install_grass.sh
@@ -33,13 +33,14 @@ install_version() {
     local GRASS_COLLAPSED_VERSION="$2"
     local GRASS_GIT_VERSION="$3"
 
+    local CODE_DIR="$GRASS_INSTALL_REPO/grass-code-$GRASS_DOT_VERSION"
     local CONDA_PREFIX="$BASE_DIR/grass-$GRASS_DOT_VERSION"
     local INSTALL_PREFIX="$CONDA_PREFIX"
 
     conda env create --file "$GRASS_INSTALL_REPO/environment.yml" --prefix "$CONDA_PREFIX"
     export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
     conda activate "$CONDA_PREFIX"
-    "$GRASS_INSTALL_REPO/compile.sh" "$GRASS_GIT_VERSION" "$CONDA_PREFIX" "$INSTALL_PREFIX"
+    "$GRASS_INSTALL_REPO/compile.sh" "$CODE_DIR" "$GRASS_GIT_VERSION" "$CONDA_PREFIX" "$INSTALL_PREFIX"
 
     if [ ! -f "$INSTALL_PREFIX/bin/grass" ]; then
         echo >&2 "Plain grass command not in bin, creating symlink"
@@ -58,7 +59,7 @@ install_version() {
 
     "$GRASS_INSTALL_REPO/record_metadata.sh" \
         "$CONDA_PREFIX" \
-        "$GRASS_INSTALL_REPO/grass-code-$GRASS_DOT_VERSION" \
+        "$CODE_DIR" \
         "$MODULE_FILES_DIR" \
         "$GRASS_DOT_VERSION" \
         "$GRASS_GIT_VERSION"


### PR DESCRIPTION
* Automatically create a record from the install script. It is easier to delete it than to write the command.
* Fix name of the module creation script.
