### PR TITLE
Update GRASS branch name from master to main

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: master
+          - version: main
             command: grass
           - version: releasebranch_7_8
             command: grass78

--- a/available/8.0-2021-06-24/metadata.yml
+++ b/available/8.0-2021-06-24/metadata.yml
@@ -5,8 +5,8 @@ module_load: grass/8.0-2021-06-24
 module_example: |
   module use --append /usr/local/usrapps/geospatial/modulefiles/
   module load grass/8.0-2021-06-24
-cloned_version: master
-branch: master
+cloned_version: main
+branch: main
 commit: 8ed47e4b764bc0884de57b5c5bc68118155f815b
 repo: https://github.com/OSGeo/grass.git
 local_changes: |

--- a/available/8.0-2021-07-26/metadata.yml
+++ b/available/8.0-2021-07-26/metadata.yml
@@ -5,8 +5,8 @@ module_load: grass/8.0-2021-07-26
 module_example: |
   module use --append /usr/local/usrapps/geospatial/modulefiles
   module load grass/8.0-2021-07-26
-cloned_version: master
-branch: master
+cloned_version: main
+branch: main
 commit: d03c8cb72e326a4ea421596b778304f7eafd4bea
 repo: https://github.com/OSGeo/grass.git
 local_changes: |

--- a/available/8.0-2021-08-11/metadata.yml
+++ b/available/8.0-2021-08-11/metadata.yml
@@ -5,8 +5,8 @@ module_load: grass/8.0-2021-08-11
 module_example: |
   module use --append /usr/local/usrapps/geospatial/modulefiles
   module load grass/8.0-2021-08-11
-cloned_version: master
-branch: master
+cloned_version: main
+branch: main
 commit: 1b87e6ccb90fe243124cdfd360a4e460801367e4
 repo: https://github.com/OSGeo/grass.git
 local_changes: |

--- a/docs/available.md
+++ b/docs/available.md
@@ -22,9 +22,9 @@ These are all the currently installed (available) versions. (New versions are in
 |----------------|------------------------------------|-------------------|--------------------------------------------|
 | 7.8-2021-06-24 | `module load grass/7.8-2021-06-24` | releasebranch_7_8 | `eb4d84acbfe021f89bdee2895fd96ab974f8563f` |
 | 7.8-2021-07-29 | `module load grass/7.8-2021-07-29` | releasebranch_7_8 | `42f015eb5e02c5e9f6d828dbe15a3120e8ad60d9` |
-| 8.0-2021-06-24 | `module load grass/8.0-2021-06-24` | master            | `8ed47e4b764bc0884de57b5c5bc68118155f815b` |
-| 8.0-2021-07-26 | `module load grass/8.0-2021-07-26` | master            | `d03c8cb72e326a4ea421596b778304f7eafd4bea` |
-| 8.0-2021-08-11 | `module load grass/8.0-2021-08-11` | master            | `1b87e6ccb90fe243124cdfd360a4e460801367e4` |
+| 8.0-2021-06-24 | `module load grass/8.0-2021-06-24` | main              | `8ed47e4b764bc0884de57b5c5bc68118155f815b` |
+| 8.0-2021-07-26 | `module load grass/8.0-2021-07-26` | main              | `d03c8cb72e326a4ea421596b778304f7eafd4bea` |
+| 8.0-2021-08-11 | `module load grass/8.0-2021-08-11` | main              | `1b87e6ccb90fe243124cdfd360a4e460801367e4` |
 
 ## See also
 

--- a/install_grass.sh
+++ b/install_grass.sh
@@ -13,9 +13,9 @@ if [[ $# -ne 4 ]]; then
     echo >&2 "Usage: $0 INSTALL_DIR VERSION_WITH_DOTS COLLAPSED_VERSION BRANCH_OR_TAG"
     echo >&2 "Examples:"
     echo >&2 "  $0 /your/path 7.8.5 78 7.8.5"
-    echo >&2 "  $0 /your/path 7.9 79 master"
+    echo >&2 "  $0 /your/path 7.9 79 main"
     echo >&2 "  $0 /your/path 7.8-\$(date -I) 78 releasebranch_7_8"
-    echo >&2 "  $0 /your/path 8.0-$(date -I) 80 master"
+    echo >&2 "  $0 /your/path 8.0-$(date -I) 80 main"
     exit 1
 fi
 


### PR DESCRIPTION
* The default/development branch in GRASS GIS repo was renamed from master to main.
* This updates the CI to get the correct branch.
* Updates examples for clarity.
* Importantly, this updates also the records for the existing versions. Although they were made from master and not main,
  there is no branch master anymore and the branch they were made from is now called main.
