### PR TITLE
Add 8.2 branch and workflow dispatch

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -18,6 +18,7 @@ on:
   schedule:
     # At 03:30 on Wednesday.
     - cron: "30 3 * * 3"
+  workflow_dispatch:
 
 jobs:
   build:
@@ -27,6 +28,8 @@ jobs:
       matrix:
         include:
           - version: main
+            command: grass
+          - version: releasebranch_8_2
             command: grass
           - version: releasebranch_8_0
             command: grass


### PR DESCRIPTION
* Add 8.2 branch of GRASS GIS.
* Add workflow dispatch to CI to trigger the builds manually.